### PR TITLE
consumer added with option to have multiple consumer groups

### DIFF
--- a/consumer.js
+++ b/consumer.js
@@ -1,0 +1,24 @@
+const { kafka } = require('./client');
+const group = process.argv[2];
+
+console.log(process.argv)
+
+const init = async () => {
+    const consumer = kafka.consumer({groupId: group});
+
+    console.log('Started Connecting to Consumer.....')
+    await consumer.connect();
+    console.log('Consumer Connected Successfully.....')
+
+
+    await consumer.subscribe({topics: ['messages'], fromBeginning: true});
+
+    await consumer.run({
+      eachMessage: async ({topic, partition, message, heartbeat, pause}) => {
+        console.log(`${group}: [${topic}]: PART: ${partition}`, message.value.toString());
+      }
+    })
+
+}
+
+init()


### PR DESCRIPTION
<img width="1168" alt="Screenshot 2024-06-30 at 6 07 58 PM" src="https://github.com/danitrical/kafka_implementation/assets/90336478/73477975-6144-4eec-983f-b3dc2d20438d">

As you can see in the image, we have 2 consumer groups and 1 producer.

Consumer 1: con-den-1 having 2 consumers
Consumer 2: con-den-2 having 1 consumers

So, I have a logic in my code, if the 3rd argument of the message is 1, then it is added to partition with index = 0 otherwise to partition with index  = 1.

So, in case of consumer group, based on the number of consumers in the group, it will load balance automatically.